### PR TITLE
Fix Missing Parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,6 +6,7 @@ define puppet_device (
   Boolean                $debug        = false,
   Integer[0,1440]        $run_interval = 0,
   Boolean                $run_via_exec = false,
+  Boolean                $run_via_cron = false,
   Enum[present, absent]  $ensure       = present,
 ) {
 


### PR DESCRIPTION
* In 'class puppet_device::devices' the 'puppet_device' defined type
  is called with a parameter that is missing in the defined type
  (run_via_cron).
* This commit adds the parameter to the defined type even if not used.