### PR TITLE
automatically include the device module base class

### DIFF
--- a/manifests/devices.pp
+++ b/manifests/devices.pp
@@ -53,12 +53,13 @@ class puppet_device::devices(Hash $devices = {}) {
 
   ($hiera_devices + $devices).each |$title, $device| {
     puppet_device {$title:
-      name         => $device['name'],
-      type         => $device['type'],
-      url          => $device['url'],
-      debug        => $device['debug'],
-      run_interval => $device['run_interval'],
-      run_via_exec => $device['run_via_exec'],
+      name           => $device['name'],
+      type           => $device['type'],
+      url            => $device['url'],
+      debug          => $device['debug'],
+      run_interval   => $device['run_interval'],
+      run_via_exec   => $device['run_via_exec'],
+      include_module => $device['include_module'],
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,12 +2,13 @@
 
 define puppet_device (
   String[1]              $type,
-  String                 $url          = '',
-  Hash                   $credentials  = {},
-  Boolean                $debug        = false,
-  Integer[0,1440]        $run_interval = 0,
-  Boolean                $run_via_exec = false,
-  Enum[present, absent]  $ensure       = present,
+  String                 $url            = '',
+  Hash                   $credentials    = {},
+  Boolean                $debug          = false,
+  Integer[0,1440]        $run_interval   = 0,
+  Boolean                $run_via_exec   = false,
+  Boolean                $include_module = true,
+  Enum[present, absent]  $ensure         = present,
 ) {
 
   # Validate node.
@@ -70,4 +71,12 @@ define puppet_device (
     puppet_device::run::via_exec::device { $name: }
   }
 
+  # Device modules often implement a base class that implements an install class.
+  # Automatically include that base class to install any requirements of the module.
+
+  # TODO: Consider including the ("${type}::install") class instead.
+
+  if ($ensure == present) and ($include_module == true) and defined($type) {
+    include $type
+  }
 }

--- a/spec/defines/init_spec.rb
+++ b/spec/defines/init_spec.rb
@@ -1,17 +1,24 @@
 require 'spec_helper'
 
 describe 'puppet_device' do
+  let(:pre_condition) do
+    [
+      'class cisco_ios {}',
+      'class f5 {}',
+    ]
+  end
+
   context 'declared on a device' do
     let(:title)  { 'cisco.example.com' }
     let(:params) do
       {
         :ensure       => :present,
-        :type         => 'cisco-ios',
+        :type         => 'cisco_ios',
       }
     end
     let(:facts) do
       {
-        :os => { :family => 'cisco-ios' },
+        :os => { :family => 'cisco_ios' },
       }
     end
 
@@ -41,6 +48,7 @@ describe 'puppet_device' do
     it { is_expected.to contain_puppet_device(title) }
     it { is_expected.to contain_class('puppet_device::conf') }
     it { is_expected.to contain_class('puppet_device::fact') }
+    it { is_expected.to contain_class('F5') }
   end
 
   context 'declared on Windows, running Puppet 5.0, with values for all device.conf parameters' do
@@ -67,6 +75,7 @@ describe 'puppet_device' do
     it { is_expected.to contain_puppet_device(title) }
     it { is_expected.to contain_class('puppet_device::conf') }
     it { is_expected.to contain_class('puppet_device::fact') }
+    it { is_expected.to contain_class('F5') }
   end
 
   context 'declared on Linux, running Puppet 4.10, with run_interval' do
@@ -92,6 +101,7 @@ describe 'puppet_device' do
     it { is_expected.to contain_puppet_device(title) }
     it { is_expected.to contain_class('puppet_device::conf') }
     it { is_expected.to contain_class('puppet_device::fact') }
+    it { is_expected.to contain_class('F5') }
     it { is_expected.to contain_puppet_device__run__via_cron__device(title) }
     it {
       is_expected.to contain_cron('run puppet_device').with(
@@ -123,6 +133,7 @@ describe 'puppet_device' do
     it { is_expected.to contain_puppet_device(title) }
     it { is_expected.to contain_class('puppet_device::conf') }
     it { is_expected.to contain_class('puppet_device::fact') }
+    it { is_expected.to contain_class('F5') }
     it { is_expected.to contain_puppet_device__run__via_cron__device(title) }
     it {
       is_expected.to contain_cron("run puppet_device target #{title}").with(
@@ -156,6 +167,7 @@ describe 'puppet_device' do
     it { is_expected.to contain_puppet_device(title) }
     it { is_expected.to contain_class('puppet_device::conf') }
     it { is_expected.to contain_class('puppet_device::fact') }
+    it { is_expected.to contain_class('F5') }
     it { is_expected.to contain_puppet_device__run__via_scheduled_task__device(title) }
     it {
       is_expected.to contain_scheduled_task("run puppet_device target #{title}").with(
@@ -189,6 +201,8 @@ describe 'puppet_device' do
     it { is_expected.to contain_puppet_device(title) }
     it { is_expected.to contain_class('puppet_device::conf') }
     it { is_expected.to contain_class('puppet_device::fact') }
+    it { is_expected.to contain_class('F5') }
+
     it { is_expected.to contain_puppet_device__run__via_exec__device(title) }
     it {
       is_expected.to contain_exec("run puppet_device target #{title}").with(
@@ -226,7 +240,7 @@ describe 'puppet_device' do
     let(:params) do
       {
         :ensure       => :present,
-        :type         => 'cisco-ios',
+        :type         => 'cisco_ios',
         :credentials  => { 'address' => '10.0.0.245', 'port' => 22, 'username' => 'admin', 'password' => 'cisco', 'enable_password' => 'cisco' },
       }
     end
@@ -244,6 +258,7 @@ describe 'puppet_device' do
     it { is_expected.to contain_puppet_device(title) }
     it { is_expected.to contain_class('puppet_device::conf') }
     it { is_expected.to contain_class('puppet_device::fact') }
+    it { is_expected.to contain_class('Cisco_ios') }
 
     # TODO: Identify the rspec syntax for matching an attribute value containing newlines.
     # Or, Identify the rspec syntax for substring matching an attribute value.
@@ -293,7 +308,7 @@ describe 'puppet_device' do
     let(:params) do
       {
         :ensure       => :present,
-        :type         => 'cisco-ios',
+        :type         => 'cisco_ios',
         :credentials  => { 'address' => '10.0.0.245', 'port' => 22, 'username' => 'admin', 'password' => 'cisco', 'enable_password' => 'cisco' },
         :url          => 'https://admin:cisco@10.0.0.245/',
       }


### PR DESCRIPTION
This eliminates the need to manually apply the device module (in this case`f5`) class ...

```
node 'agent.example.com' {
  class {'f5': }
  puppet_device {'bigip.example.com':
    type         => 'f5',
    url          => 'https://admin:fffff55555@10.0.0.245/',
  }
}
```

```
node 'agent.example.com' {
  puppet_device {'bigip.example.com':
    type         => 'f5',
    url          => 'https://admin:fffff55555@10.0.0.245/',
  }
}
```

... which (in this case, applies the `f5::install` class) which installs the `faraday` gem 
on the proxy Puppet agent:

```
...
Notice: /Stage[main]/F5::Install/Package[faraday]/ensure: created
...
```

This can be specified by the optional `include module` parameter, which defaults to `true` and checks if the class is defined before attempting to apply. This could instead apply the device module `::install` class, especially if we define an `::install` class as a contract with device module developers (aka TAPP partners).